### PR TITLE
Switch over to using Text-based body parser

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,6 +14,9 @@ export function requireSignedRequest(options: SignatureMiddlewareOptions): Reque
   return function ensureSignedRequest(request, response, next) {
     try {
       assertValidRequest(request, options.secret)
+      if (typeof request.body === 'string') {
+        request.body = JSON.parse(request.body)
+      }
       next()
     } catch (err) {
       if (!respondOnError || !isSignatureError(err)) {

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -51,8 +51,12 @@ export function assertValidRequest(request: ConnectLikeRequest, secret: string):
     throw new WebhookSignatureFormatError('Request contained no parsed request body')
   }
 
-  const payload = JSON.stringify(request.body)
-  assertValidSignature(payload, signature, secret)
+  if (typeof request.body === 'string') {
+    assertValidSignature(request.body, signature, secret)
+  } else {
+    const payload = JSON.stringify(request.body)
+    assertValidSignature(payload, signature, secret)
+  }
 }
 
 export function isValidRequest(request: ConnectLikeRequest, secret: string): boolean {

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -1,5 +1,5 @@
 import express, {Express, NextFunction, Request, RequestHandler, Response} from 'express'
-import {json} from 'body-parser'
+import {json, text} from 'body-parser'
 import request from 'supertest'
 import {isSignatureError, requireSignedRequest, SIGNATURE_HEADER_NAME} from '../src'
 
@@ -8,103 +8,114 @@ describe('middleware', () => {
   const signature = 't=1633519811129,v1=tLa470fx7qkLLEcMOcEUFuBbRSkGujyskxrNXcoh0N0'
   const secret = 'test'
 
-  describe('requireSignedRequest (respond on success)', () => {
-    test('passes valid requests', () => {
-      return request(getApp(requireSignedRequest({secret})))
-        .post('/hook')
-        .set('Content-Type', 'application/json')
-        .set(SIGNATURE_HEADER_NAME, signature)
-        .send(payload)
-        .expect({success: true})
-        .expect(200)
+  describe.each([
+    ['json', json()],
+    ['text', text({type: 'application/json'})],
+  ])('%s middleware', (_, middleware) => {
+    describe('requireSignedRequest (respond on success)', () => {
+      test('passes valid requests', () => {
+        return request(getApp(middleware, requireSignedRequest({secret})))
+          .post('/hook')
+          .set('Content-Type', 'application/json')
+          .set(SIGNATURE_HEADER_NAME, signature)
+          .send(payload)
+          .expect({success: true})
+          .expect(200)
+      })
+
+      test('passes valid requests', () => {
+        return request(getApp(middleware, requireSignedRequest({secret})))
+          .post('/hook')
+          .set('Content-Type', 'application/json')
+          .set(SIGNATURE_HEADER_NAME, signature)
+          .send(payload)
+          .expect({success: true})
+          .expect(200)
+      })
+
+      test('fails if no signature is present', () => {
+        return request(getApp(middleware, requireSignedRequest({secret})))
+          .post('/hook')
+          .set('Content-Type', 'application/json')
+          .send(payload)
+          .expect({message: 'Request contained no signature header'})
+          .expect(401)
+      })
+
+      test('fails if signature is invalid (hash)', () => {
+        return request(getApp(middleware, requireSignedRequest({secret})))
+          .post('/hook')
+          .set('Content-Type', 'application/json')
+          .set(SIGNATURE_HEADER_NAME, signature.slice(0, -5))
+          .send(payload)
+          .expect({message: 'Signature is invalid'})
+          .expect(401)
+      })
+
+      test('fails if signature format is invalid (timestamp)', () => {
+        return request(getApp(middleware, requireSignedRequest({secret})))
+          .post('/hook')
+          .set('Content-Type', 'application/json')
+          .set(SIGNATURE_HEADER_NAME, 't=1633519811,v1=tLa470fx7qkLLEcMOcEUFuBbRSkGujyskxrNXcoh0N0')
+          .send(payload)
+          .expect({
+            message:
+              'Invalid signature timestamp, must be a unix timestamp with millisecond precision',
+          })
+          .expect(400)
+      })
+
+      test('fails if signature format is invalid (format)', () => {
+        return request(getApp(middleware, requireSignedRequest({secret})))
+          .post('/hook')
+          .set('Content-Type', 'application/json')
+          .set(SIGNATURE_HEADER_NAME, 't=1633519811123,v4=tLa470fx7qkLLEcMOcEUFuBbRS')
+          .send(payload)
+          .expect({message: 'Invalid signature payload format'})
+          .expect(400)
+      })
+
+      test('fails if signature format is invalid (payload)', () => {
+        return request(getApp(middleware, requireSignedRequest({secret})))
+          .post('/hook')
+          .set('Content-Type', 'application/json')
+          .set(SIGNATURE_HEADER_NAME, signature)
+          .send({foo: 'bar'})
+          .expect({message: 'Signature is invalid'})
+          .expect(401)
+      })
     })
 
-    test('fails if no body parsing middleware present', () => {
-      const app = express()
-      app.post('/hook', requireSignedRequest({secret}), (req, res) => res.json({success: true}))
-      app.use(errorHandler)
+    describe('requireSignedRequest (use error handler)', () => {
+      test('passes valid requests', () => {
+        return request(getApp(middleware, requireSignedRequest({secret, respondOnError: false})))
+          .post('/hook')
+          .set('Content-Type', 'application/json')
+          .set(SIGNATURE_HEADER_NAME, signature)
+          .send(payload)
+          .expect({success: true})
+          .expect(200)
+      })
 
-      return request(app)
-        .post('/hook')
-        .set('Content-Type', 'application/json')
-        .set(SIGNATURE_HEADER_NAME, signature)
-        .send(payload)
-        .expect({message: 'Request contained no parsed request body'})
-        .expect(400)
-    })
-
-    test('fails if no signature is present', () => {
-      return request(getApp(requireSignedRequest({secret})))
-        .post('/hook')
-        .set('Content-Type', 'application/json')
-        .send(payload)
-        .expect({message: 'Request contained no signature header'})
-        .expect(401)
-    })
-
-    test('fails if signature is invalid (hash)', () => {
-      return request(getApp(requireSignedRequest({secret})))
-        .post('/hook')
-        .set('Content-Type', 'application/json')
-        .set(SIGNATURE_HEADER_NAME, signature.slice(0, -5))
-        .send(payload)
-        .expect({message: 'Signature is invalid'})
-        .expect(401)
-    })
-
-    test('fails if signature format is invalid (timestamp)', () => {
-      return request(getApp(requireSignedRequest({secret})))
-        .post('/hook')
-        .set('Content-Type', 'application/json')
-        .set(SIGNATURE_HEADER_NAME, 't=1633519811,v1=tLa470fx7qkLLEcMOcEUFuBbRSkGujyskxrNXcoh0N0')
-        .send(payload)
-        .expect({
-          message:
-            'Invalid signature timestamp, must be a unix timestamp with millisecond precision',
-        })
-        .expect(400)
-    })
-
-    test('fails if signature format is invalid (format)', () => {
-      return request(getApp(requireSignedRequest({secret})))
-        .post('/hook')
-        .set('Content-Type', 'application/json')
-        .set(SIGNATURE_HEADER_NAME, 't=1633519811123,v4=tLa470fx7qkLLEcMOcEUFuBbRS')
-        .send(payload)
-        .expect({message: 'Invalid signature payload format'})
-        .expect(400)
-    })
-
-    test('fails if signature format is invalid (payload)', () => {
-      return request(getApp(requireSignedRequest({secret})))
-        .post('/hook')
-        .set('Content-Type', 'application/json')
-        .set(SIGNATURE_HEADER_NAME, signature)
-        .send({foo: 'bar'})
-        .expect({message: 'Signature is invalid'})
-        .expect(401)
+      test('fails if no signature is present', () => {
+        return request(getApp(middleware, requireSignedRequest({secret, respondOnError: false})))
+          .post('/hook')
+          .set('Content-Type', 'application/json')
+          .send(payload)
+          .expect({message: 'Request contained no signature header', success: false})
+          .expect(401)
+      })
     })
   })
 
-  describe('requireSignedRequest (use error handler)', () => {
-    test('passes valid requests', () => {
-      return request(getApp(requireSignedRequest({secret, respondOnError: false})))
-        .post('/hook')
-        .set('Content-Type', 'application/json')
-        .set(SIGNATURE_HEADER_NAME, signature)
-        .send(payload)
-        .expect({success: true})
-        .expect(200)
-    })
-
-    test('fails if no signature is present', () => {
-      return request(getApp(requireSignedRequest({secret, respondOnError: false})))
-        .post('/hook')
-        .set('Content-Type', 'application/json')
-        .send(payload)
-        .expect({message: 'Request contained no signature header', success: false})
-        .expect(401)
-    })
+  test('fails if no body parsing middleware present', () => {
+    return request(getApp(requireSignedRequest({secret})))
+      .post('/hook')
+      .set('Content-Type', 'application/json')
+      .set(SIGNATURE_HEADER_NAME, signature)
+      .send(payload)
+      .expect({message: 'Request contained no parsed request body'})
+      .expect(400)
   })
 })
 
@@ -120,10 +131,9 @@ function errorHandler(err: Error, req: Request, res: Response, next: NextFunctio
   res.status(err.statusCode).json({message: err.message, success: false})
 }
 
-function getApp(middleware: RequestHandler): Express {
+function getApp(...middleware: RequestHandler[]): Express {
   const app = express()
-  app.use(json())
-  app.post('/hook', middleware, (req, res) => res.json({success: true}))
+  app.post('/hook', ...middleware, (req, res) => res.json({success: true}))
   app.use(errorHandler)
   return app
 }

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -19,7 +19,7 @@ describe('middleware', () => {
           .set('Content-Type', 'application/json')
           .set(SIGNATURE_HEADER_NAME, signature)
           .send(payload)
-          .expect({success: true})
+          .expect({success: true, payload})
           .expect(200)
       })
 
@@ -29,7 +29,7 @@ describe('middleware', () => {
           .set('Content-Type', 'application/json')
           .set(SIGNATURE_HEADER_NAME, signature)
           .send(payload)
-          .expect({success: true})
+          .expect({success: true, payload})
           .expect(200)
       })
 
@@ -93,7 +93,7 @@ describe('middleware', () => {
           .set('Content-Type', 'application/json')
           .set(SIGNATURE_HEADER_NAME, signature)
           .send(payload)
-          .expect({success: true})
+          .expect({success: true, payload})
           .expect(200)
       })
 
@@ -133,7 +133,7 @@ function errorHandler(err: Error, req: Request, res: Response, next: NextFunctio
 
 function getApp(...middleware: RequestHandler[]): Express {
   const app = express()
-  app.post('/hook', ...middleware, (req, res) => res.json({success: true}))
+  app.post('/hook', ...middleware, (req, res) => res.json({success: true, payload: req.body}))
   app.use(errorHandler)
   return app
 }


### PR DESCRIPTION
This is needed because the previous approach would give signature errors when the JSON didn't round-trip.