### PR TITLE
feat: warn if request body is not a string/buffer

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,17 +4,19 @@ import {assertValidRequest} from './signature'
 
 export interface SignatureMiddlewareOptions {
   secret: string
+  parseBody?: boolean
   respondOnError?: boolean
 }
 
 export function requireSignedRequest(options: SignatureMiddlewareOptions): RequestHandler {
+  const parseBody = typeof options.parseBody === 'undefined' ? true : options.parseBody
   const respondOnError =
     typeof options.respondOnError === 'undefined' ? true : options.respondOnError
 
   return function ensureSignedRequest(request, response, next) {
     try {
       assertValidRequest(request, options.secret)
-      if (typeof request.body === 'string') {
+      if (parseBody && typeof request.body === 'string') {
         request.body = JSON.parse(request.body)
       }
       next()

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -4,6 +4,17 @@ import request from 'supertest'
 import {isSignatureError, requireSignedRequest, SIGNATURE_HEADER_NAME} from '../src'
 
 describe('middleware', () => {
+  let warn: jest.SpyInstance | undefined
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    if (warn) {
+      warn.mockReset()
+    }
+  })
+
   const payload = {_id: 'resume'}
   const signature = 't=1633519811129,v1=tLa470fx7qkLLEcMOcEUFuBbRSkGujyskxrNXcoh0N0'
   const secret = 'test'

--- a/test/signature.test.ts
+++ b/test/signature.test.ts
@@ -9,6 +9,17 @@ import {
 } from '../src'
 
 describe('signature', () => {
+  let warn: jest.SpyInstance | undefined
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    if (warn) {
+      warn.mockReset()
+    }
+  })
+
   describe('isValidSignature', () => {
     const secret = 'test'
 


### PR DESCRIPTION
I suggest we:

- Warn the user if the request body is not a string/Buffer, since it can lead to incorrect signatures.
- Release a 2.0.0 which _throws_ if the request body is not a string/Buffer

This PR implements the warning, and if accepted, I will also create a 2.x branch that throws.